### PR TITLE
Docs on gh-pages

### DIFF
--- a/.github/workflows/pub_docs.yml
+++ b/.github/workflows/pub_docs.yml
@@ -3,7 +3,7 @@ name: Publish Sphinx docs to gh-pages
 on: push
 
 jobs:
-  build:
+  deploy-ghpages:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 2
@@ -29,11 +29,14 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package and build docs 📦
         run: |
+          # install pip
           python -m pip install --upgrade pip
-          sudo apt-get install libgsl-dev
+          # install eko
+          sudo apt-get install libgsl-dev # eko dependency
           cd eko
           pip install .
           cd ..
+          # install yadism
           pip install .
       - name: Build 🔨
         run: |


### PR DESCRIPTION
Fix gh-pages docs deployment workflow.

Brief description of the workflow:
1. checkout the repo and `eko` submodule
2. install `eko` and its dependencies
3. install the module
4. build the docs with sphinx
5. deploy to `gh-pages` branch only the built html