### PR TITLE
Remove extra-factor of 1/2 in XSFPF

### DIFF
--- a/src/yadism/esf/exs.py
+++ b/src/yadism/esf/exs.py
@@ -68,7 +68,7 @@ def xs_coeffs(kind, y, x=None, Q2=None, params=None):
         yL = y**2 / (2 * (y**2 / 2 + (1 - y) - (mn * x * y) ** 2 / Q2))
     elif kind == "XSFPFCC":
         INV_GEV_TO_PB = GEV_CM2_CONV / 100.0  # pb
-        norm = (INV_GEV_TO_PB * params["GF"] ** 2) / (4.0 * np.pi)
+        norm = (INV_GEV_TO_PB * params["GF"] ** 2) / (2.0 * np.pi)
         norm *= 1.0 / (2.0 * x * (1.0 + Q2 / params["M2W"]) ** 2)
     else:
         mn = np.sqrt(params["M2target"])

--- a/tests/yadism/esf/test_exs.py
+++ b/tests/yadism/esf/test_exs.py
@@ -57,7 +57,7 @@ def test_xs_coeffs():
         y=1.0,
         params=dict(projectilePID=1, M2target=0.0, M2W=1.0, GF=1.0),
     )
-    assert xsfpfcc[0] == 3.893793e8 / (32.0 * 0.5 * np.pi)
+    assert xsfpfcc[0] == 3.893793e8 / (16.0 * 0.5 * np.pi)
 
     nutev = xs_coeffs(
         "XSNUTEVCC",


### PR DESCRIPTION
This simply removes the extra factor of 1/2 in the definition of the FPF differential cross-sections.