### PR TITLE
Correct F3 and g1 in NC at NNLO and N3LO

### DIFF
--- a/src/yadism/coefficient_functions/coupling_constants.py
+++ b/src/yadism/coefficient_functions/coupling_constants.py
@@ -249,7 +249,7 @@ class CouplingConstants:
             * self.propagator_factor("phph", Q2)
             * self.partonic_coupling("phph", pid, quark_coupling_type)
         )
-        # pure photon exchane
+        # pure photon exchange
         if self.obs_config["process"] == "EM":
             return w_phph
         # allow Z to be mixed in

--- a/src/yadism/coefficient_functions/light/__init__.py
+++ b/src/yadism/coefficient_functions/light/__init__.py
@@ -14,21 +14,22 @@ Note
     *   Check the theory reference for details on
         :doc:`../theory/scale-variations`
 
-    *   At |N3LO| that the source files in fortran follows :cite:`vogt-f3cc` notation
+    *   The source files in fortran follows :cite:`vogt-f3cc` notation
         where the odd-N moments are called minus even if they correspond to :math:`\nu + \bar{\nu}`.
         This convention is changed in :cite:`Davies:2016ruz` where the complete |N3LO| CC results are presented
         for the first time. Referred equations are not always in agreement with the code conventions.
-        The code follows the notation:
 
-        F3:
-            * odd N: :math:`\nu + \bar{\nu}`, :math:`c_{ns,-}`
-            * even N: :math:`\nu - \bar{\nu}`, :math:`c_{ns,+} = \delta + c_{ns,-}`
-            * In :math:`c_{ns,+}` the term fl02 has to be turned off for CC and NC
+    The code follows the notation:
 
-        F2, FL:
-            * odd N: :math:`\nu - \bar{\nu}`, :math:`c_{ns,-} = - \delta + c_{ns,+}`
-            * even N: :math:`\nu + \bar{\nu}`, :math:`c_{ns,+}`
-            * The term fl11 has to be turned off for CC.
+    F3:
+        * odd N: :math:`\nu + \bar{\nu}`, :math:`c_{ns,-}` common for CC and NC (up to N3LO).
+        * even N: :math:`\nu - \bar{\nu}`, :math:`c_{ns,+} = \delta + c_{ns,-}` only for CC.
+        * In :math:`c_{ns,+}` the term fl02 has to be turned off for CC.
+
+    F2, FL:
+        * odd N: :math:`\nu - \bar{\nu}`, :math:`c_{ns,-} = - \delta + c_{ns,+}` only for CC.
+        * even N: :math:`\nu + \bar{\nu}`, :math:`c_{ns,+}` common for CC and NC (up to N3LO).
+        * The term fl11 has to be turned off for CC.
 
 """
 

--- a/src/yadism/coefficient_functions/light/__init__.py
+++ b/src/yadism/coefficient_functions/light/__init__.py
@@ -14,7 +14,7 @@ Note
     *   Check the theory reference for details on
         :doc:`../theory/scale-variations`
 
-    *   The source files in fortran follows :cite:`vogt-f3cc` notation
+    *   The source files (available in fortran) follow the notations in :cite:`vogt-f3cc`
         where the odd-N moments are called minus even if they correspond to :math:`\nu + \bar{\nu}`.
         This convention is changed in :cite:`Davies:2016ruz` where the complete |N3LO| CC results are presented
         for the first time. Referred equations are not always in agreement with the code conventions.

--- a/src/yadism/coefficient_functions/light/f3_cc.py
+++ b/src/yadism/coefficient_functions/light/f3_cc.py
@@ -1,8 +1,9 @@
 """
-Note that at |N3LO| the source files in fortran follow :cite:`vogt-f3cc` notation
-where the odd-N moments are called minus even if they correspond to :math:`\nu + \bar{\nu}`.
+Note that the source files in fortran follow :cite:`vogt-f3cc` notation
+where the odd-N moments are called minus even if they correspond to :math:`\nu + \bar{\nu}`,
+while even-N moments are called plus even if they correspond to :math:`\nu - \bar{\nu}`.
 This convention is changed in :cite:`Davies:2016ruz` where the |N3LO| CC results are presented
-for the first time. Referred equations are not always in agreement with the code conventions.
+for the first time.
 """
 
 from .. import partonic_channel as pc
@@ -16,23 +17,18 @@ class NonSingletOdd(f3_nc.NonSinglet):
 
 class NonSingletEven(f3_nc.NonSinglet):
     def NNLO(self):
-        """
-        |ref| implements :eqref:`3.6`, :cite:`vogt-f3cc`
-        or :eqref:`2.8`, :cite:`Davies:2016ruz`.
-        """
+        """|ref| implements the sum between :eqref:`2.8` and :eqref:`3.5`, :cite:`Davies:2016ruz`."""
         return RSL(
             nnlo.xc3ns2p.c3np2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3np2c, [self.nf]
         )
 
     def N3LO(self):
-        """
-        |ref| implements :eqref:`3.7`, :cite:`vogt-f3cc` or :eqref:`2.11`, :cite:`Davies:2016ruz`.
-        """
+        """|ref| implements the sum between :eqref:`2.11` and :eqref:`3.8`, :cite:`Davies:2016ruz`."""
         return RSL(
             n3lo.xc3ns3p.c3np3a,
             n3lo.xc3ns3p.c3ns3b,
             n3lo.xc3ns3p.c3np3c,
-            [self.nf],
+            [self.nf, False],
         )
 
 

--- a/src/yadism/coefficient_functions/light/f3_cc.py
+++ b/src/yadism/coefficient_functions/light/f3_cc.py
@@ -32,7 +32,7 @@ class NonSingletEven(f3_nc.NonSinglet):
             n3lo.xc3ns3p.c3np3a,
             n3lo.xc3ns3p.c3ns3b,
             n3lo.xc3ns3p.c3np3c,
-            [self.nf, True],
+            [self.nf],
         )
 
 

--- a/src/yadism/coefficient_functions/light/f3_cc.py
+++ b/src/yadism/coefficient_functions/light/f3_cc.py
@@ -11,31 +11,29 @@ from . import f3_nc, n3lo, nnlo
 
 
 class NonSingletOdd(f3_nc.NonSinglet):
+    pass
+
+
+class NonSingletEven(f3_nc.NonSinglet):
     def NNLO(self):
         """
         |ref| implements :eqref:`3.6`, :cite:`vogt-f3cc`
         or :eqref:`2.8`, :cite:`Davies:2016ruz`.
         """
-
         return RSL(
-            nnlo.xc3ns2p.c3nm2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3nm2c, [self.nf]
+            nnlo.xc3ns2p.c3np2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3np2c, [self.nf]
         )
 
     def N3LO(self):
         """
         |ref| implements :eqref:`3.7`, :cite:`vogt-f3cc` or :eqref:`2.11`, :cite:`Davies:2016ruz`.
         """
-
         return RSL(
-            n3lo.xc3ns3p.c3nm3a,
+            n3lo.xc3ns3p.c3np3a,
             n3lo.xc3ns3p.c3ns3b,
-            n3lo.xc3ns3p.c3nm3c,
+            n3lo.xc3ns3p.c3np3c,
             [self.nf, True],
         )
-
-
-class NonSingletEven(f3_nc.NonSinglet):
-    pass
 
 
 class Gluon(pc.EmptyPartonicChannel):

--- a/src/yadism/coefficient_functions/light/f3_cc.py
+++ b/src/yadism/coefficient_functions/light/f3_cc.py
@@ -1,5 +1,5 @@
 """
-Note that the source files in fortran follow :cite:`vogt-f3cc` notation
+Note that the source files (given in fortran) follow the notations in :cite:`vogt-f3cc`
 where the odd-N moments are called minus even if they correspond to :math:`\nu + \bar{\nu}`,
 while even-N moments are called plus even if they correspond to :math:`\nu - \bar{\nu}`.
 This convention is changed in :cite:`Davies:2016ruz` where the |N3LO| CC results are presented

--- a/src/yadism/coefficient_functions/light/f3_nc.py
+++ b/src/yadism/coefficient_functions/light/f3_nc.py
@@ -1,6 +1,4 @@
-"""
-See :mod:`f3_cc` docstring for the name conventions.
-"""
+"""See :mod:`f3_cc` docstring for the name conventions."""
 
 from .. import partonic_channel as pc
 from ..partonic_channel import RSL
@@ -10,29 +8,21 @@ from . import f2_nc, n3lo, nlo, nnlo
 class NonSinglet(f2_nc.NonSinglet):
     @staticmethod
     def NLO():
-        """
-        |ref| implements :eqref:`155`, :cite:`moch-f3nc`.
-        """
+        """|ref| implements :eqref:`155`, :cite:`moch-f3nc`."""
 
         return RSL.from_distr_coeffs(
             nlo.f3.ns_reg, (nlo.f2.ns_delta, nlo.f2.ns_omx, nlo.f2.ns_logomx)
         )
 
     def NNLO(self):
-        """
-        |ref| implements the sum between :eqref:`2.8` and :eqref:`3.5`, :cite:`Davies:2016ruz`
-        or :eqref:`208`, :cite:`moch-f3nc`.
-        """
+        """|ref| implements :eqref:`3.6` :cite:`vogt-f3cc`, or :eqref:`208`, :cite:`moch-f3nc`, or :eqref:`2.8` :cite:`Davies:2016ruz`."""
 
         return RSL(
             nnlo.xc3ns2p.c3nm2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3nm2c, [self.nf]
         )
 
     def N3LO(self):
-        """
-        |ref| implements the sum between :eqref:`2.11` and :eqref:`3.8`, :cite:`Davies:2016ruz`.
-        """
-
+        """|ref| implements :eqref:`3.7` :cite:`vogt-f3cc`, or :eqref:`2.11` :cite:`Davies:2016ruz`."""
         return RSL(
             n3lo.xc3ns3p.c3nm3a,
             n3lo.xc3ns3p.c3ns3b,

--- a/src/yadism/coefficient_functions/light/f3_nc.py
+++ b/src/yadism/coefficient_functions/light/f3_nc.py
@@ -25,7 +25,7 @@ class NonSinglet(f2_nc.NonSinglet):
         """
 
         return RSL(
-            nnlo.xc3ns2p.c3np2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3np2c, [self.nf]
+            nnlo.xc3ns2p.c3nm2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3nm2c, [self.nf]
         )
 
     def N3LO(self):
@@ -34,9 +34,9 @@ class NonSinglet(f2_nc.NonSinglet):
         """
 
         return RSL(
-            n3lo.xc3ns3p.c3np3a,
+            n3lo.xc3ns3p.c3nm3a,
             n3lo.xc3ns3p.c3ns3b,
-            n3lo.xc3ns3p.c3np3c,
+            n3lo.xc3ns3p.c3nm3c,
             [self.nf, False],
         )
 

--- a/src/yadism/coefficient_functions/light/f3_nc.py
+++ b/src/yadism/coefficient_functions/light/f3_nc.py
@@ -37,7 +37,7 @@ class NonSinglet(f2_nc.NonSinglet):
             n3lo.xc3ns3p.c3nm3a,
             n3lo.xc3ns3p.c3ns3b,
             n3lo.xc3ns3p.c3nm3c,
-            [self.nf, False],
+            [self.nf, True],
         )
 
 

--- a/src/yadism/coefficient_functions/light/g1_nc.py
+++ b/src/yadism/coefficient_functions/light/g1_nc.py
@@ -35,7 +35,7 @@ class NonSinglet(pc.LightBase):
         """
 
         return RSL(
-            nnlo.xc3ns2p.c3np2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3np2c, [self.nf]
+            nnlo.xc3ns2p.c3nm2a, nnlo.xc3ns2p.c3ns2b, nnlo.xc3ns2p.c3nm2c, [self.nf]
         )
 
 

--- a/src/yadism/coefficient_functions/light/n3lo/xc3ns3p.py
+++ b/src/yadism/coefficient_functions/light/n3lo/xc3ns3p.py
@@ -153,7 +153,7 @@ def c3nm3c(y, args):
 @nb.njit("f8(f8,f8[:])", cache=True)
 def c3np3a(y, args):
     # Here we need to remove the fl02 diagrams
-    return c3nm3a(y, [args[0], False]) + c3q3dfp(y, args)
+    return c3nm3a(y, args) + c3q3dfp(y, args)
 
 
 @nb.njit("f8(f8,f8[:])", cache=True)

--- a/src/yadism/coefficient_functions/light/n3lo/xc3ns3p.py
+++ b/src/yadism/coefficient_functions/light/n3lo/xc3ns3p.py
@@ -152,7 +152,8 @@ def c3nm3c(y, args):
 
 @nb.njit("f8(f8,f8[:])", cache=True)
 def c3np3a(y, args):
-    return c3nm3a(y, args) + c3q3dfp(y, args)
+    # Here we need to remove the fl02 diagrams
+    return c3nm3a(y, [args[0], False]) + c3q3dfp(y, args)
 
 
 @nb.njit("f8(f8,f8[:])", cache=True)


### PR DESCRIPTION
We were using the wrong combination of CC coefficients to implement the non singlet NC F3 at NNLO and N3LO. 
This might explain why Fig3 of the Yadism paper was much worst than the other benchmarks and might have an impact on the polarized `g1` 

**TODO:**
* [x] Check the impact on `g1` (FONLL polarized paper)
* [x] Check the benchmark with Apfel++ `g1` (Yadism paper Fig3) @giacomomagni 
* [ ] Check impact on some FKtables
* [x] Check the impact on the IC valence paper, F3 plot. @giacomomagni 

@felixhekhorn @Radonirinaunimi @RoyStegeman 