### PR TITLE
Different hotfixes

### DIFF
--- a/src/yadbox/export.py
+++ b/src/yadbox/export.py
@@ -106,7 +106,8 @@ def dump_pineappl_to_file(output, filename, obsname):
     # Define the convolution type of the initial state hadron
     conv_type = "PolPDF" if obsname.startswith("g") else "UnpolPDF"
     grid.set_key_value("convolution_type_1", conv_type)
+    grid.set_key_value("convolution_type_2", str(None))
 
     # dump file
     grid.optimize()
-    grid.write(filename)
+    grid.write_lz4(filename)

--- a/src/yadism/coefficient_functions/coupling_constants.py
+++ b/src/yadism/coefficient_functions/coupling_constants.py
@@ -412,12 +412,13 @@ class CouplingConstants:
         CouplingConstants
             created object
         """
+        ckm_matrix = theory["CKM"]
+        if isinstance(ckm_matrix, str):
+            ckm_matrix = CKM2Matrix.from_str(ckm_matrix)
         theory_config = {
             "MZ2": theory.get("MZ", 91.1876)
             ** 2,  # TODO remove defaults to the PDG2020 value
-            "CKM": CKM2Matrix.from_str(
-                theory["CKM"]
-            ),  # TODO remove default in PDG2020 Eq. 12.33
+            "CKM": ckm_matrix,
             "sin2theta_weak": theory.get(
                 "SIN2TW", 0.23121
             ),  # TODO remove defaults to the PDG2020 value

--- a/src/yadism/coefficient_functions/intrinsic/g1_nc.py
+++ b/src/yadism/coefficient_functions/intrinsic/g1_nc.py
@@ -1,0 +1,8 @@
+from ..partonic_channel import EmptyPartonicChannel
+
+
+class Splus(EmptyPartonicChannel):
+    pass
+
+class Sminus(EmptyPartonicChannel):
+    pass

--- a/src/yadism/coefficient_functions/intrinsic/g4_nc.py
+++ b/src/yadism/coefficient_functions/intrinsic/g4_nc.py
@@ -1,0 +1,9 @@
+from ..partonic_channel import EmptyPartonicChannel
+
+
+class Splus(EmptyPartonicChannel):
+    pass
+
+class Sminus(EmptyPartonicChannel):
+    pass
+

--- a/src/yadism/coefficient_functions/intrinsic/gl_nc.py
+++ b/src/yadism/coefficient_functions/intrinsic/gl_nc.py
@@ -1,0 +1,9 @@
+from ..partonic_channel import EmptyPartonicChannel
+
+
+class Splus(EmptyPartonicChannel):
+    pass
+
+class Sminus(EmptyPartonicChannel):
+    pass
+

--- a/src/yadism/input/compatibility.py
+++ b/src/yadism/input/compatibility.py
@@ -44,9 +44,9 @@ def update_scale_variations(theory):
             theory runcard
     """
     if "RenScaleVar" not in theory:
-        theory["RenScaleVar"] = not np.isclose(theory["XIR"], 1.0)
+        theory["RenScaleVar"] = True
     if "FactScaleVar" not in theory:
-        theory["FactScaleVar"] = not np.isclose(theory["XIF"], 1.0)
+        theory["FactScaleVar"] = True
 
 
 def update_target(obs):
@@ -140,7 +140,7 @@ def update_fns(theory):
     else:
         raise ValueError(f"Scheme '{fns}' not recognized.")
 
-    if "PTODIS" not in theory:
+    if "PTODIS" not in theory or theory["PTODIS"] is None:
         theory["PTODIS"] = theory["PTO"]
 
     if "FONLLParts" not in theory:


### PR DESCRIPTION
This PR includes 3 different hotfixes to make yadism running again. 

* Fix new pineappl convention.
* Add empty IC coefficient functions for polarized structure functions (needed since we have dropped `IC`).
* Update theory cards compatibility layer, according to the new NNPPDF runcards. 

The only change that is not strictly necessary is setting `RenScaleVar,FactScaleVar` to `True` if the key is not present. 
I find this change quite handy to speed up the computation of scale varied theories, but if you don't like it
I'm happy to drop it. 
