### PR TITLE
Prepare for aQg30 from Blumlein

### DIFF
--- a/extras/heavy_em_n3lo/README.md
+++ b/extras/heavy_em_n3lo/README.md
@@ -3,12 +3,11 @@ In order to compute all the N3LO grids run
 python produce_grids.py
 
 cores=4
-order=3
 
 for nf in 3 4 5; do
     for kind in 2 L; do
         for channel in g q; do
-            python yad_grids.py $nf $cores $kind $channel $order gm;
+            python yad_grids.py $nf $cores $kind $channel ;
         done
     done
 done

--- a/extras/heavy_em_n3lo/yad_grids.py
+++ b/extras/heavy_em_n3lo/yad_grids.py
@@ -19,27 +19,16 @@ channel = sys.argv[4]
 if channel not in ["q", "g"]:
     raise ValueError("Set channel to 'g' or 'q'")
 
-order = int(sys.argv[5])
-
-if sys.argv[6] not in ["klmv", "abmp", "gm"]:
-    raise ValueError("Set hs_version to 'klmv', 'abmp' or 'gm'")
-# klmv = Kawamura, Lo Presti, Moch, Vogt: approximation from [arXiv:1205.5727]
-# abmp = Alekhin, Blumlein, Moch, Placakyte: approximation from [arXiv:1701.05838]
-# gm = approximation from Giacomo Magni, based on the results of [arXiv:2403.00513]
-
+order = 3
 
 mufrac = 1.0
 verbose = True
 
-hs_version = "exact" if channel == "q" else sys.argv[6]
-if order > 1:
-    massive = adani.ApproximateCoefficientFunction(
-        order, kind, channel, True, hs_version
-    )
-elif order == 1:
-    massive = adani.ExactCoefficientFunction(order, kind, channel)
-else:
-    raise ValueError("Set order to 1, 2 or 3!")
+hs_version = "exact"
+
+massive = adani.ApproximateCoefficientFunction(
+    order, kind, channel, True, hs_version
+)
 
 
 def x_eta(eta, m2Q2):
@@ -79,7 +68,7 @@ if __name__ == "__main__":
 
     if verbose:
         print(
-            f"Computation of the grid for the coefficient function C{kind}{channel} for nf = {nf}, and µ/Q = {mufrac}"
+            f"Computation of the grid for the coefficient function C_{kind}{channel}^{order} for nf = {nf}, and µ/Q = {mufrac}"
         )
         print(f"Size of the grid (eta,xi) = ({len(eta_grid)},{len(xi_grid)})")
         print(
@@ -95,8 +84,6 @@ if __name__ == "__main__":
     res_mat = res_vec.reshape(len(xi_grid), len(eta_grid), 3)
 
     for variation in range(-1, 1 + 1):
-        if order == 1 and variation in [-1, 1]:
-            continue
         if verbose:
             print(f"Saving {variation} grid in ", here / output_files[variation])
         np.save(here / output_files[variation], res_mat[:, :, variation + 1])

--- a/src/yadism/coefficient_functions/asy/f2_nc.py
+++ b/src/yadism/coefficient_functions/asy/f2_nc.py
@@ -7,7 +7,7 @@ from . import raw_nc
 
 
 class AsyGluon(pc.NeutralCurrentBaseAsy):
-    hs3 = adani.HighScaleSplitLogs(3, "2", "g", "gm")
+    hs3 = adani.HighScaleSplitLogs(3, "2", "g", "exact")
 
 
 class AsySinglet(pc.NeutralCurrentBaseAsy):

--- a/src/yadism/coefficient_functions/asy/fl_nc.py
+++ b/src/yadism/coefficient_functions/asy/fl_nc.py
@@ -11,7 +11,7 @@ class AsyLLGluon(EmptyPartonicChannel):
 
 
 class AsyGluon(pc.NeutralCurrentBaseAsy):
-    hs3 = adani.HighScaleSplitLogs(3, "L", "g", "gm")
+    hs3 = adani.HighScaleSplitLogs(3, "L", "g", "exact")
 
 
 class AsySinglet(pc.NeutralCurrentBaseAsy):


### PR DESCRIPTION
Preparing code for the exact form of $a_{Qg}^{(3,0)}$ from Blumlein:
once that the numerical values of $a_{Qg}^{(3,0)}$ will be public (Blumlein said that there will be a code release soon).

For whoever is going to take care of this, once that these numbers are public you have to:
- implement them in PR n. 52 from Adani (everything is ready you just have to put the x-grid and the corresponding values of $a_{Qg}^{(3,0)}$)
- create tag v1.0.4 in Adani
- update the adani version in the pyproject.toml
- regenerate the grids running the README.md in `extras/heavy_em_n3lo`
- merge

P.S. pay attention that Blumlein produced $a_{Qg}^{(3)} = a_{Qg}^{(3,0)} + n_f a_{Qg}^{(3,1)}$ (at least he did it in the paper) so you need to subtract the $n_f$ dependent part