### PR TITLE
Fix CKM as list

### DIFF
--- a/src/yadism/coefficient_functions/coupling_constants.py
+++ b/src/yadism/coefficient_functions/coupling_constants.py
@@ -415,6 +415,8 @@ class CouplingConstants:
         ckm_matrix = theory["CKM"]
         if isinstance(ckm_matrix, str):
             ckm_matrix = CKM2Matrix.from_str(ckm_matrix)
+        elif isinstance(ckm_matrix, list):
+            ckm_matrix = CKM2Matrix(np.array([ckm_matrix]) ** 2)
         theory_config = {
             "MZ2": theory.get("MZ", 91.1876)
             ** 2,  # TODO remove defaults to the PDG2020 value


### PR DESCRIPTION
In the new nnpdf runcards `CKM` is a list, however it was not passed correctly to yadism. 

I think here we have been lucky no one was doing CC DIS grids since a while...