### PR TITLE
Implements `F4` and `F5` structure functions for CC DIS

### DIFF
--- a/src/yadism/coefficient_functions/light/f4_cc.py
+++ b/src/yadism/coefficient_functions/light/f4_cc.py
@@ -1,0 +1,17 @@
+from .. import partonic_channel as epc
+
+# In the massless limit, F4 vanishes both at LO and NLO.
+# Only when heavy quark masses are accounted for that its
+# contribution is non-zero.
+
+
+class Gluon(epc.EmptyPartonicChannel):
+    pass
+
+
+class Singlet(epc.EmptyPartonicChannel):
+    pass
+
+
+class Valence(epc.EmptyPartonicChannel):
+    pass

--- a/src/yadism/coefficient_functions/light/f5_cc.py
+++ b/src/yadism/coefficient_functions/light/f5_cc.py
@@ -1,0 +1,11 @@
+from ..partonic_channel import RSL
+from . import partonic_channel as pc
+
+# At LO, only the Non-Singlet part is non-zero and is proportional to
+# `delta`. Starting at NLO, the Gluon part starts to contribute.
+
+
+class NongSinglet(pc.LightBase):
+    @staticmethod
+    def LO():
+        return RSL.from_delta(1.0)

--- a/src/yadism/esf/exs.py
+++ b/src/yadism/esf/exs.py
@@ -8,6 +8,12 @@ GEV_CM2_CONV = 3.893793e10
 "Conversion factor from GeV^-2 to 10^-38 cm^2"
 
 
+# TODO: For both `xs_coeffs_unpolarized` and `EvaluatedCrossSection.get_result()`,
+# instead of returning an array of 3 elements, now it should return 5, with the
+# las two corresponding to `F4` and `F5`. This is what will allow us to compute
+# the (differential) cross-sections.
+
+
 def xs_coeffs_polarized(kind):
     """Compute coefficients in the definition of a given polarized cross section.
 

--- a/src/yadism/observable_name.py
+++ b/src/yadism/observable_name.py
@@ -7,7 +7,7 @@ with and whether or not the given flavor is heavy.
 """
 
 fake_kind = "??"
-sfs = ["F2", "FL", "F3", "g1", "gL", "g4"]
+sfs = ["F2", "FL", "F3", "g1", "gL", "g4", "F4", "F5"]
 # xs = ["XSreduced", "XSyreduced"]
 xs = [
     "XSHERANC",


### PR DESCRIPTION
Hi @reinaldofrancener, here is a minimal change to start the implementation of the $F_{4,5}$ structure functions for the $\nu_\tau$ CC DIS. The implementation up to NLO accuracy shouldn't be difficult as the expressions are rather short.