### PR TITLE
Adding cross section observables

### DIFF
--- a/src/yadism/esf/exs.py
+++ b/src/yadism/esf/exs.py
@@ -112,6 +112,12 @@ def xs_coeffs_unpolarized(kind, y, x=None, Q2=None, params=None):
         # NUTEV neutrino dis
         if kind == "XSNUTEVNU":
             norm = GEV_CM2_CONV * params["GF"] ** 2 * mn / (2.0 * np.pi)
+    if kind == "DSIGMADXDQ2":
+        norm = (
+            params["GF"] ** 2
+            / (2 * np.pi * x)
+            * (params["M2W"] / (Q2 + params["M2W"])) ** 2
+        )
     return np.array([yp, -yL, f3sign * ym]) * norm
 
 

--- a/src/yadism/observable_name.py
+++ b/src/yadism/observable_name.py
@@ -20,6 +20,7 @@ xs = [
     "F1",
     "g5",
     "XSFPFCC",
+    "DSIGMADXDQ2",
 ]
 kinds = sfs + xs + [fake_kind]
 # external flavors:


### PR DESCRIPTION
- added dsigma_dxdq2 as a derived observable. this can now be computed

The way I do this is pretty simple: I add to `src/yadism/esf/exs.py` a new observable, namely the double differential cross section in `x` and `Q2`, since yadism has native support for this. If we want to get a fully integrated distriution, this would require substantially more work. 

I will proceed with adding also some other distributions