### PR TITLE
Remove `grid.optimize()`

### DIFF
--- a/src/yadbox/export.py
+++ b/src/yadbox/export.py
@@ -138,5 +138,4 @@ def dump_pineappl_to_file(output, filename, obsname):
     grid.set_metadata("y_label", obsname)
 
     # dump file
-    grid.optimize()
     grid.write_lz4(filename)


### PR DESCRIPTION
I overlooked the implementation of `.optimize_using()` in the Python API for the `Grid` object. And given that it would take some time to release PineAPPL `v1.4.0`, we have to go for the drastic change. This unfortunately means that we do not have access to the following optimizations:

- `GridOptFlags::OPTIMIZE_SUBGRID_TYPE` to optimize storage efficiency
- `GridOptFlags::OPTIMIZE_NODES` to remove unnecessary interpolation scales
- `GridOptFlags::{SYMMETRIZE_CHANNELS,MERGE_SAME_CHANNELS,STRIP_EMPTY_CHANNELS}` to optimize channel structures

These ofc imply that not only the grids (and hence FK tables) will be (slightly) bigger but might also increase the time to compute the EKOs. We can obviously do the absolute correct thing but this would take time.